### PR TITLE
Fixed chat based unit tests by bypassing slowchat

### DIFF
--- a/Mixer.UnitTests/UnitTestBase.cs
+++ b/Mixer.UnitTests/UnitTestBase.cs
@@ -18,6 +18,7 @@ namespace Mixer.UnitTests
             OAuthClientScopeEnum.channel__analytics__self,
             OAuthClientScopeEnum.channel__streamKey__self,
 
+            OAuthClientScopeEnum.chat__bypass_slowchat,
             OAuthClientScopeEnum.chat__chat,
             OAuthClientScopeEnum.chat__clear_messages,
             OAuthClientScopeEnum.chat__connect,


### PR DESCRIPTION
The chat unit tests were being throttled by slowchat.  The chat::bypass_slowchat scope lets the bot/test bypass that limitation.