### PR TITLE
Added OAuthClientScopeEnum for clips

### DIFF
--- a/Mixer.Base/MixerConnection.cs
+++ b/Mixer.Base/MixerConnection.cs
@@ -26,6 +26,8 @@ namespace Mixer.Base
         channel__partnership__self,
         channel__streamKey__self,
         channel__update__self,
+        channel__clip__create__self,
+        channel__clip__delete__self,
         chat__bypass_links,
         chat__bypass_slowchat,
         chat__change_ban,


### PR DESCRIPTION
2 new scopes need to be added for creating and deleting clips.   The Mixer account should need  Channel Editor permissions to create and delete clips.