### PR TITLE
The Youtube parameters should be decoded to prevent encoded entities in the tokens and values

### DIFF
--- a/StreamingClient.Base/Web/LocalHttpListenerServer.cs
+++ b/StreamingClient.Base/Web/LocalHttpListenerServer.cs
@@ -127,7 +127,10 @@ namespace StreamingClient.Base.Web
                     {
                         token = token.Substring(0, endIndex);
                     }
-                    return token;
+
+                    String decodedToken = HttpUtility.UrlDecode(token);
+
+                    return decodedToken;
                 }
             }
             return null;


### PR DESCRIPTION
Received tokens and other parameters in the url query could contain encoded entities and invalidates the token when send to Youtube, To mitigate this we should decode the received query parameters and use that to request an access token.