### PR TITLE
Fixed null reference exception 

### DIFF
--- a/Twitch/Twitch.Base/Models/NewAPI/NewTwitchAPIDataRestResult.cs
+++ b/Twitch/Twitch.Base/Models/NewAPI/NewTwitchAPIDataRestResult.cs
@@ -27,6 +27,6 @@ namespace Twitch.Base.Models.NewAPI
         /// <summary>
         /// The pagination cursor.
         /// </summary>
-        public string Cursor { get { return (this.pagination.ContainsKey("cursor")) ? this.pagination["cursor"].ToString() : null; } }
+        public string Cursor { get { return (this.pagination!=null && this.pagination.ContainsKey("cursor")) ? this.pagination["cursor"].ToString() : null; } }
     }
 }


### PR DESCRIPTION
Some New APIs don't return pagination information when retrieving a subset of items.  In those cases pagination in the NewTwitchAPIDataRestResults will be null.   When getting the Cursor a null check was not occurring for pagination so it could cause a null reference exception to be thrown.

I was seeing this issue specifically with the GetSubscriptions api when filtering by a single user id.