### PR TITLE
Trovo: fixes grabbing channels by username

### DIFF
--- a/Trovo/Trovo.Base/Services/ChannelsService.cs
+++ b/Trovo/Trovo.Base/Services/ChannelsService.cs
@@ -71,7 +71,7 @@ namespace Trovo.Base.Services
             Validator.ValidateString(username, "username");
 
             JObject requestParameters = new JObject();
-            requestParameters["user_name"] = username;
+            requestParameters["username"] = username;
 
             return await this.PostAsync<ChannelModel>("channels/id", AdvancedHttpClient.CreateContentFromObject(requestParameters));
         }


### PR DESCRIPTION
ref: https://developer.trovo.live/docs/APIs.html#_5-5-get-channel-info-by-id
they've changed the parameter from "user_name" to "username". :)