### PR TITLE
Add ability to retrieve client only Channel Points

### DIFF
--- a/Twitch/Twitch.Base/Services/NewAPI/ChannelPointsService.cs
+++ b/Twitch/Twitch.Base/Services/NewAPI/ChannelPointsService.cs
@@ -63,11 +63,12 @@ namespace Twitch.Base.Services.NewAPI
         /// Gets all rewards associated with the broadcaster.
         /// </summary>
         /// <param name="broadcaster">The broadcaster to get rewards for</param>
+        /// <param name="clientOnly">Determines whether to get only the rewards for the client_id provided</param>
         /// <returns>The reward information</returns>
-        public async Task<IEnumerable<CustomChannelPointRewardModel>> GetCustomRewards(UserModel broadcaster)
+        public async Task<IEnumerable<CustomChannelPointRewardModel>> GetCustomRewards(UserModel broadcaster, bool clientOnly = false)
         {
             Validator.ValidateVariable(broadcaster, "broadcaster");
-            return await this.GetPagedDataResultAsync<CustomChannelPointRewardModel>("channel_points/custom_rewards?broadcaster_id=" + broadcaster.id, maxResults: int.MaxValue);
+            return await this.GetPagedDataResultAsync<CustomChannelPointRewardModel>("channel_points/custom_rewards?broadcaster_id=" + broadcaster.id + "&only_manageable_rewards=" + clientOnly, maxResults: int.MaxValue);
         }
 
         /// <summary>

--- a/Twitch/Twitch.Base/Services/NewAPI/ChannelPointsService.cs
+++ b/Twitch/Twitch.Base/Services/NewAPI/ChannelPointsService.cs
@@ -63,9 +63,9 @@ namespace Twitch.Base.Services.NewAPI
         /// Gets all rewards associated with the broadcaster.
         /// </summary>
         /// <param name="broadcaster">The broadcaster to get rewards for</param>
-        /// <param name="clientOnly">Determines whether to get only the rewards for the client_id provided</param>
+        /// <param name="managableRewardsOnly">Whether to return only rewards manageable by the current client application</param>
         /// <returns>The reward information</returns>
-        public async Task<IEnumerable<CustomChannelPointRewardModel>> GetCustomRewards(UserModel broadcaster, bool clientOnly = false)
+        public async Task<IEnumerable<CustomChannelPointRewardModel>> GetCustomRewards(UserModel broadcaster, bool managableRewardsOnly = false)
         {
             Validator.ValidateVariable(broadcaster, "broadcaster");
             return await this.GetPagedDataResultAsync<CustomChannelPointRewardModel>("channel_points/custom_rewards?broadcaster_id=" + broadcaster.id + "&only_manageable_rewards=" + clientOnly, maxResults: int.MaxValue);

--- a/Twitch/Twitch.Base/Services/NewAPI/ChannelPointsService.cs
+++ b/Twitch/Twitch.Base/Services/NewAPI/ChannelPointsService.cs
@@ -68,7 +68,7 @@ namespace Twitch.Base.Services.NewAPI
         public async Task<IEnumerable<CustomChannelPointRewardModel>> GetCustomRewards(UserModel broadcaster, bool managableRewardsOnly = false)
         {
             Validator.ValidateVariable(broadcaster, "broadcaster");
-            return await this.GetPagedDataResultAsync<CustomChannelPointRewardModel>("channel_points/custom_rewards?broadcaster_id=" + broadcaster.id + "&only_manageable_rewards=" + clientOnly, maxResults: int.MaxValue);
+            return await this.GetPagedDataResultAsync<CustomChannelPointRewardModel>("channel_points/custom_rewards?broadcaster_id=" + broadcaster.id + "&only_manageable_rewards=" + managableRewardsOnly, maxResults: int.MaxValue);
         }
 
         /// <summary>


### PR DESCRIPTION
This will allow us to retireve the channel points that are editable by out application. I would like to be able to allow users to edit their channel points within my app. Currently there is no way to get this information from the twitch api, this will add that functionality.