### PR TITLE
Fixed issue with Twitch OAuth force_verify parameter

### DIFF
--- a/Twitch/Twitch.Base/TwitchConnection.cs
+++ b/Twitch/Twitch.Base/TwitchConnection.cs
@@ -264,7 +264,7 @@ namespace Twitch.Base
 
             if (forceApprovalPrompt)
             {
-                parameters.Add("force_verify", "force");
+                parameters.Add("force_verify", "true");
             }
 
             FormUrlEncodedContent content = new FormUrlEncodedContent(parameters.AsEnumerable());


### PR DESCRIPTION
The force_verify parameter for Twitch OAuth should be a boolean.  The prior value of "force" did not work.
https://dev.twitch.tv/docs/authentication/getting-tokens-oauth/#oauth-implicit-code-flow